### PR TITLE
curriculum-back/package.json, README.md: add npm i

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To see the playlist where I livestream the building of this app, [click here](ht
 
 1. Open another terminal tab or window
 1. `cd curriculum-back`
+1. `npm i`
 1. `npm run setup`
 1. `npm start`
 

--- a/curriculum-back/package.json
+++ b/curriculum-back/package.json
@@ -12,7 +12,7 @@
     "test": "jest --coverage",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "eslint --ignore-path .gitignore . --fix",
-    "setup": "concurrently \"npm i\" \"cp sample-env .env\"",
+    "setup": "cp sample-env .env",
     "start": "cross-env NODE_ENV=local npx nodemon app.js",
     "debug": "npx nodemon --inspect app.js",
     "preprod": "npm i --production",


### PR DESCRIPTION
to setup backend (curriculum-back/), npm run setup assumes that conncurrently is installed globally:

in curriculum-back/package.json:
"setup": "concurrently \"npm i\" \"cp sample-env .env\""

Instead, we can just run npm i then run npm setup, where setup is: "setup": "cp sample-env .env"